### PR TITLE
References are now an array

### DIFF
--- a/src/Fable.REPL/fcs.fs
+++ b/src/Fable.REPL/fcs.fs
@@ -80,7 +80,7 @@ let convertGlyph glyph =
         Glyph.Event
 
 let createChecker references readAllBytes =
-    InteractiveChecker.Create(List.ofArray references, readAllBytes)
+    InteractiveChecker.Create(references, readAllBytes)
 
 let createCompiler replacements =
     Compiler()


### PR DESCRIPTION
Really minor breaking change :) in the interest of easier js interop (arrays vs lists).  FCS.Fable latest.