### PR TITLE
Collapse samples

### DIFF
--- a/src/App/Main.fs
+++ b/src/App/Main.fs
@@ -96,7 +96,7 @@ let updateLayouts _ =
 let update msg model =
     match msg with
     | StartCompile ->
-        { model with State = Compiling }, Cmd.performFunc editor.CompileAndRunCurrentResults () EndCompile
+        { model with State = Compiling }, Cmd.performFunc editor.CompileAndRunCurrentResults editorFsharp EndCompile
 
     | EndCompile (codeES2015, codeAMD) ->
         { model with State = Compiled
@@ -291,8 +291,7 @@ let private editorArea model dispatch =
                         ClassName "editor-fsharp"
                         OnKeyDown (fun ev ->
                           if ev.altKey && ev.key = "Enter" then
-                              dispatch StartCompile
-                        )
+                              dispatch StartCompile)
                         Ref (fun element ->
                               if not (isNull element) then
                                 if element.childElementCount = 0. then
@@ -314,6 +313,9 @@ let private editorArea model dispatch =
                           Fa.faLg ] ] ]
               Card.content [ Card.props [ Style [ Display htmlDisplay ] ] ]
                 [ div [ ClassName "editor-html"
+                        OnKeyDown (fun ev ->
+                          if ev.altKey && ev.key = "Enter" then
+                              dispatch StartCompile)
                         Ref (fun element ->
                                 if not (isNull element) then
                                     if element.childElementCount = 0. then

--- a/src/App/Sidebar.fs
+++ b/src/App/Sidebar.fs
@@ -7,8 +7,6 @@ type Model =
       Samples : Samples.Model }
 
 type Msg =
-    | Expand
-    | Collapse
     | SamplesMsg of Samples.Msg
 
 type ExternalMsg =
@@ -16,17 +14,11 @@ type ExternalMsg =
     | NoOp
 
 let init _ =
-    { IsExpanded = true
+    { IsExpanded = false
       Samples = Samples.init () }
 
 let update msg model =
     match msg with
-    | Expand ->
-        { model with IsExpanded = true }, Cmd.none, NoOp
-
-    | Collapse ->
-        { model with IsExpanded = false }, Cmd.none,NoOp
-
     | SamplesMsg msg ->
         let (samplesModel, samplesCmd, externalMsg) = Samples.update msg model.Samples
 
@@ -39,21 +31,15 @@ let update msg model =
 
 open Fable.Helpers.React
 open Fable.Helpers.React.Props
-open Fulma.Elements
-open Fulma.Extra.FontAwesome
 open Fulma.Components
 
-let view model dispatch =
-    div [ ClassName "sidebar" ]
-        [ Card.card [ ]
-            [ Card.header [ ]
-                [ Card.Header.title [ ]
-                    [ str "Samples" ]
-                  Card.Header.icon [ ]
-                    [ Icon.faIcon [ ]
-                        [ Fa.icon Fa.I.AngleUp
-                          Fa.faLg ] ] ]
-              Card.content [ ]
-                [ Samples.view model.Samples (SamplesMsg >> dispatch)
-                ] ]
-        ]
+let view (model: Model) dispatch =
+    if model.IsExpanded then
+        div [ ClassName "sidebar" ]
+            [ Card.card [ ]
+                [ Card.content [ ]
+                    [ Samples.view model.Samples (SamplesMsg >> dispatch)
+                    ] ]
+            ]
+    else
+        div [] []

--- a/src/Monaco/Editor.fs
+++ b/src/Monaco/Editor.fs
@@ -21,13 +21,15 @@ let runAst(jsonAst: string): string * string = importMember "./util.js"
 let mutable fcsChecker: IChecker option = None
 let mutable fcsResults: IParseResults option = None
 
-let compileAndRunCurrentResults () =
-    match fcsResults with
-    | Some res ->
+let compileAndRunCurrentResults (ed: monaco.editor.IStandaloneCodeEditor) =
+    match fcsChecker with
+    | None -> "", ""
+    | Some fcsChecker ->
+        let content = ed.getModel().getValue(monaco.editor.EndOfLinePreference.TextDefined, true)
+        let res = FableREPL.ParseFSharpProject(fcsChecker, FILE_NAME, content)
         let com = FableREPL.CreateCompiler("fable-core")
         let jsonAst = FableREPL.CompileToBabelJsonAst(com, res, FILE_NAME)
         runAst jsonAst
-    | None -> "", ""
 
 let convertGlyph glyph =
     match glyph with
@@ -160,4 +162,4 @@ let fableEditor =
 
         member __.ParseEditor editor = parseEditor editor
 
-        member __.CompileAndRunCurrentResults () = compileAndRunCurrentResults  () }
+        member __.CompileAndRunCurrentResults ed = compileAndRunCurrentResults ed }

--- a/src/Monaco/Interface.fs
+++ b/src/Monaco/Interface.fs
@@ -5,7 +5,7 @@ open Fable.Import
 type IExports =
     abstract CreateFSharpEditor : Browser.HTMLElement -> monaco.editor.IStandaloneCodeEditor
     abstract ParseEditor : monaco.editor.IModel -> unit
-    abstract CompileAndRunCurrentResults : unit -> string * string
+    abstract CompileAndRunCurrentResults : monaco.editor.IStandaloneCodeEditor -> string * string
     // abstract FcsCheckerStart : Event<unit>
     // abstract FcsCheckerEnd : Event<unit>
     // abstract FcsCompilerStart : Event<unit>


### PR DESCRIPTION
Fix #14 and also fix the problem with old JS compilation by forcing F# AST parsing every time the Compile button (or Alt+Enter shortcut) is clicked.