### PR TITLE
Add tooltips

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -114,9 +114,11 @@
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
+        <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+        <PrivateAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'true'">All</PrivateAssets>
       </PackageReference>
     </ItemGroup>
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,10 +4,10 @@ storage:none
 clitool dotnet-fable prerelease
 nuget Fable.Core prerelease
 nuget Fable.Import.Browser
-nuget Fable.React 2.0.0-beta-001
+nuget Fable.React prerelease
 nuget Fulma prerelease
 nuget Fable.Elmish
-nuget Fable.Elmish.React 1.0.1-beta-1
+nuget Fable.Elmish.React prerelease
 nuget Thot.Json
 nuget Fable.PowerPack
 

--- a/paket.lock
+++ b/paket.lock
@@ -1,23 +1,23 @@
 STORAGE: NONE
 NUGET
   remote: https://www.nuget.org/api/v2
-    dotnet-fable (1.3.6) - clitool: true
+    dotnet-fable (1.3.7) - clitool: true
       Dotnet.ProjInfo (>= 0.9) - restriction: >= netcoreapp2.0
-      Fable.Compiler (>= 1.3.6) - restriction: >= netcoreapp2.0
-      Fable.Core (>= 1.3.6) - restriction: >= netcoreapp2.0
+      Fable.Compiler (>= 1.3.7) - restriction: >= netcoreapp2.0
+      Fable.Core (>= 1.3.7) - restriction: >= netcoreapp2.0
       FSharp.Core (>= 4.2.3) - restriction: >= netcoreapp2.0
       Microsoft.NETCore.App (>= 2.0) - restriction: >= netcoreapp2.0
     Dotnet.ProjInfo (0.9) - restriction: >= netcoreapp2.0
       FSharp.Core (>= 4.2.3) - restriction: && (< net45) (>= netstandard2.0)
-    Fable.Compiler (1.3.6) - restriction: >= netcoreapp2.0
-      Fable.Core (>= 1.3.6) - restriction: >= netstandard1.6
+    Fable.Compiler (1.3.7) - restriction: >= netcoreapp2.0
+      Fable.Core (>= 1.3.7) - restriction: >= netstandard1.6
       FSharp.Compiler.Service (>= 17.0.1) - restriction: >= netstandard1.6
       FSharp.Core (>= 4.2.3) - restriction: >= netstandard1.6
       Newtonsoft.Json (>= 10.0.3) - restriction: >= netstandard1.6
       System.Collections.Immutable (>= 1.4) - restriction: >= netstandard1.6
       System.Reflection.Metadata (>= 1.5) - restriction: >= netstandard1.6
       System.Runtime.Loader (>= 4.3) - restriction: >= netstandard1.6
-    Fable.Core (1.3.6)
+    Fable.Core (1.3.7)
       FSharp.Core (>= 4.2.3) - restriction: >= netstandard1.6
       NETStandard.Library (>= 1.6.1) - restriction: >= netstandard1.6
     Fable.Elmish (1.0.1)
@@ -34,11 +34,11 @@ NUGET
       Fable.Core (>= 1.1.15) - restriction: >= netstandard1.6
       FSharp.Core (>= 4.2.3) - restriction: >= netstandard1.6
       NETStandard.Library (>= 1.6.1) - restriction: >= netstandard1.6
-    Fable.PowerPack (1.3.1)
-      Fable.Core (>= 1.2.4) - restriction: >= netstandard1.6
+    Fable.PowerPack (1.3.2)
+      Fable.Core (>= 1.3.7) - restriction: >= netstandard1.6
       Fable.Import.Browser (>= 0.1.2) - restriction: >= netstandard1.6
       FSharp.Core (>= 4.2.3) - restriction: >= netstandard1.6
-    Fable.React (2.0.0-beta-001)
+    Fable.React (2.0.0-beta-002)
       Fable.Core (>= 1.2.4) - restriction: >= netstandard1.6
       Fable.Import.Browser (>= 0.1) - restriction: >= netstandard1.6
       FSharp.Core (>= 4.2.3) - restriction: >= netstandard1.6
@@ -734,15 +734,15 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    Thot.Json (0.1.0-beta-001)
+    Thot.Json (0.1.0-beta-003)
       Fable.Core (>= 1.3.4) - restriction: >= netstandard1.6
       FSharp.Core (>= 4.2.3) - restriction: >= netstandard1.6
 GITHUB
   remote: fable-compiler/Fable
-    src/dotnet/Fable.JS/Interfaces.fs (5333b3d53eae1ac56d6cd1a4c4042ea975a6c88c)
+    src/dotnet/Fable.JS/Interfaces.fs (dcde8e85c789f636401b80c1788b26cb65e2e3a6)
 GROUP Build
 RESTRICTION: == net46
 NUGET
   remote: https://www.nuget.org/api/v2
-    FAKE (4.64.2)
+    FAKE (4.64.3)
     FSharp.Core (4.2.3) - content: none, redirects: force


### PR DESCRIPTION
This is the first step to add tooltips to the REPL. In Fable, I just [exposed the `getToolTipAtLocation` function](https://github.com/fable-compiler/Fable/commit/5c323b3e4a4e513414f50854f85bc06a1fbe197b) @ncave added some time ago, and here I'm just registering the hover provider. However, the only result I get from `FableREPL.GetToolTipText` is:

```
internal error: empty list Parameter name: l
```

So I'm afraid I'll need some @ncave magic again here, any ideas?

Happy New Year btw :wink: