### PR TITLE
Fixed bad origin, Mario now actually renders.

### DIFF
--- a/public/samples/mario/mario.fs
+++ b/public/samples/mario/mario.fs
@@ -98,7 +98,7 @@ open Canvas
 open Physics
 open Fable.Import.Browser
 
-let origin = window.location.origin
+let origin = window.location.origin + "/repl/"
 
 let render (w,h) (mario: MarioModel) =
     (0., 0., w, h) |> filled (rgb 174 238 238)


### PR DESCRIPTION
Steps to reproduce: Load Mario sample, observe broken image
Resolution: add "/repl/" to origin. 

We should change out the mario gifs for less ambiguously fair use images, as well as renaming the example to "platformer". It would be pretty stupid to get a cease and desist for a code example.